### PR TITLE
Hotfix: declared rsquare variables 

### DIFF
--- a/mluem/MultipleLinearRegression.py
+++ b/mluem/MultipleLinearRegression.py
@@ -16,4 +16,6 @@ class MultipleLinearRegression(ModelInterface):
         return self._w * X
 
     def rsquare(self, X, y):
-        return 1 - (n.dot(y - self.predict(X)) / m.dot(y - np.mean(y)))
+        _m = y - np.mean(y)
+        _n = y - self.predict(X)
+        return 1 - (_n.dot(_n) / _m.dot(_m))


### PR DESCRIPTION
Declared both variables in rsquare function.
#22 